### PR TITLE
MAYH-7912 SQS message payload to FileChangeMessage, then to kafka

### DIFF
--- a/contract/file_change_message.avsc
+++ b/contract/file_change_message.avsc
@@ -1,0 +1,13 @@
+{
+  "type": "record",
+  "name": "FileChangeMessage",
+  "namespace": "net.arbor.kafka",
+  "fields": [
+    { "name": "eventName",                          "type": "string" },
+    { "name": "eventTime",                          "type": "string" },
+    { "name": "bucketName",                         "type": "string" },
+    { "name": "objectKey",                          "type": "string" },
+    { "name": "objectSize",                         "type": "long" },
+    { "name": "objectTag",                          "type": "string" }
+  ]
+}

--- a/kafka-bind.cabal
+++ b/kafka-bind.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3cec4c1d2100623d271db29ce31253086361d4f2120350321b96bc35a4999c78
+-- hash: 377b226d82bde491ec3223a814bd2f4d3c4f241838bb9a23efa86dff89f58f95
 
 name:           kafka-bind
 version:        1.0.0
@@ -17,15 +17,17 @@ build-type:     Simple
 cabal-version:  >= 1.10
 
 extra-source-files:
+    contract/file_change_message.avsc
     README.md
 
 library
   hs-source-dirs:
       src
   default-extensions: OverloadedStrings TupleSections MultiParamTypeClasses
-  ghc-options: -Wall
+  ghc-options: -W
   build-depends:
       aeson
+    , aeson-lens
     , amazonka
     , amazonka-core
     , amazonka-s3
@@ -60,6 +62,7 @@ library
     , text
     , transformers
     , transformers-base
+    , unordered-containers
   if os(osx)
     cpp-options: -D__attribute__(A)= -D_Nullable= -D_Nonnull=
   exposed-modules:
@@ -72,6 +75,7 @@ library
       App.AWS.Env
       App.AWS.S3
       App.AWS.Sqs
+      App.FileChangeMessage
       App.Kafka
       App.Options
       App.Options.Cmd
@@ -81,6 +85,7 @@ library
       App.Options.Parser
       App.Orphans
       App.RunApplication
+      App.SqsMessage
   other-modules:
       Paths_kafka_bind
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -8,6 +8,7 @@ license: MIT
 homepage: https://github.com/packetloop/kafka-bind#readme
 extra-source-files:
 - README.md
+- contract/file_change_message.avsc
 default-extensions:
 - OverloadedStrings
 - TupleSections
@@ -45,7 +46,7 @@ dependencies:
 library:
   source-dirs: src
   default-extensions: []
-  ghc-options: -Wall
+  ghc-options: -W
   exposed-modules:
   - App
   - App.Action.KafkaToSqs
@@ -56,6 +57,7 @@ library:
   - App.AWS.Env
   - App.AWS.S3
   - App.AWS.Sqs
+  - App.FileChangeMessage
   - App.Kafka
   - App.Options
   - App.Options.Cmd
@@ -65,12 +67,15 @@ library:
   - App.Options.Parser
   - App.Orphans
   - App.RunApplication
+  - App.SqsMessage
   dependencies:
   - aeson
+  - aeson-lens
   - amazonka-sqs
   - conduit-extra
   - http-types
   - optparse-applicative
+  - unordered-containers
   - split
   when:
   - condition: os(osx)

--- a/src/App/AppError.hs
+++ b/src/App/AppError.hs
@@ -12,6 +12,7 @@ import Kafka.Types
 
 data AppError = KafkaErr KafkaError
               | DecodeErr DecodeError
+              | EncodeErr EncodeError
               | AppErr String
               deriving (Show, Eq)
 instance Exception AppError

--- a/src/App/FileChangeMessage.hs
+++ b/src/App/FileChangeMessage.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module App.FileChangeMessage
+where
+
+import Data.Avro.Deriving
+
+-- automagically creates data types and ToAvro/FromAvro instances
+-- for a given schema.
+deriveAvro "contract/file_change_message.avsc"

--- a/src/App/SqsMessage.hs
+++ b/src/App/SqsMessage.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module App.SqsMessage
+  ( decodeSqsMessage
+  )
+where
+
+import App.FileChangeMessage
+import Control.Lens
+import Data.Aeson
+import Data.Aeson.Lens
+import Data.ByteString.Lazy  (fromStrict)
+import Data.Maybe            (fromMaybe)
+import Network.AWS.SQS.Types
+
+import qualified Data.ByteString.Char8 as C8
+import qualified Data.Text             as T
+
+decodeSqsMessage :: Message -> Maybe FileChangeMessage
+decodeSqsMessage sqsMessage = do
+  -- level 1
+  outermost <- sqsMessage ^. mBody
+  let sqsJSON = fromStrict $ C8.pack $ T.unpack outermost
+  sqs <- decode sqsJSON
+  -- level 2
+  messageJSON <- sqs ^. key "Message"
+  message <- decode $ fromStrict $ C8.pack messageJSON
+
+  -- from atlasdos-submissions-balancer
+
+  -- just 1 record in each sqs event
+  record     <- message    ^. key "Records" . nth 0
+  bucket     <- record     ^. key "s3"     ^. key "bucket"
+  objectAws  <- record     ^. key "s3"     ^. key "object"
+
+  eventName  <- record     ^. key "eventName"
+  eventTime  <- record     ^. key "eventTime"
+  bucketName <- bucket     ^. key "name"
+  objectKey  <- objectAws  ^. key "key"
+  objectSize <- objectAws  ^. key "size"
+  -- there is `eTag` field in ObjectCreated:Putevent and no such field in ObjectCreated:Copy
+  let objectTag = fromMaybe "" (objectAws  ^. key "eTag")
+
+  return FileChangeMessage {
+      fileChangeMessageEventName  = eventName
+    , fileChangeMessageEventTime  = eventTime
+    , fileChangeMessageBucketName = bucketName
+    , fileChangeMessageObjectKey  = objectKey
+    , fileChangeMessageObjectSize = objectSize
+    , fileChangeMessageObjectTag  = objectTag
+  }

--- a/stack.yaml
+++ b/stack.yaml
@@ -19,6 +19,7 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
   - avro-0.2.0.0
+  - aeson-lens-0.5.0.0
   - pure-zlib-0.6
   - hedgehog-0.5
   - hw-kafka-avro-1.3.0


### PR DESCRIPTION
Take AWS's S3 event payload schema and convert it into a simpler FileChangeMessage avro message, writing to the specified kafka topic.