### PR TITLE
MAYH-8054 fixed the decrement to allow backPressure to transmit

### DIFF
--- a/src/App/Options/Cmd/KafkaToSqs.hs
+++ b/src/App/Options/Cmd/KafkaToSqs.hs
@@ -119,10 +119,10 @@ backPressure queueUrl maxMessages = go 0
             case maybeNumMessages of
               Just numMessages -> if numMessages > maxMessages
                 then do
-                  liftIO $ threadDelay 1000000
+                  liftIO $ threadDelay 1000000 -- µs
                   logInfo $ "Queue " ++ show queueUrl ++ " is full"
                   go 0
-                else go (numMessages - maxMessages)
+                else go (maxMessages - numMessages)
               Nothing -> logWarn $ "Could not get queue attributes for queueUrl " ++ show queueUrl
 
 -- | Handles the stream of incoming messages.


### PR DESCRIPTION
Before, oscillation:

```
[Info] [2018-02-27 12:56:32] maxM: Just 314
[Info] [2018-02-27 12:56:32] else: -9686
[Info] [2018-02-27 12:56:32] maxM: Just 314
[Info] [2018-02-27 12:56:32] else: -9686
[Info] [2018-02-27 12:56:32] maxM: Just 314
[Info] [2018-02-27 12:56:32] else: -9686
[Info] [2018-02-27 12:56:32] maxM: Just 314
[Info] [2018-02-27 12:56:32] else: -9686
[Info] [2018-02-27 12:56:32] maxM: Just 314
[Info] [2018-02-27 12:56:32] else: -9686
[Info] [2018-02-27 12:56:32] maxM: Just 314
[Info] [2018-02-27 12:56:32] else: -9686
[Info] [2018-02-27 12:56:33] maxM: Just 314
[Info] [2018-02-27 12:56:33] else: -9686
[Info] [2018-02-27 12:56:33] maxM: Just 314
[Info] [2018-02-27 12:56:33] else: -9686
[Info] [2018-02-27 12:56:33] maxM: Just 314
[Info] [2018-02-27 12:56:33] else: -9686
[Info] [2018-02-27 12:56:33] maxM: Just 314
[Info] [2018-02-27 12:56:33] else: -9686
[Info] [2018-02-27 12:56:33] maxM: Just 314
[Info] [2018-02-27 12:56:33] else: -9686
[Info] [2018-02-27 12:56:33] maxM: Just 314
[Info] [2018-02-27 12:56:33] else: -9686
```

After:
```
[Info] [2018-02-27 12:58:02] maxM: Just 348
[Info] [2018-02-27 12:58:02] else: 12
[Info] [2018-02-27 12:58:02] transmitOneC
[Info] [2018-02-27 12:58:02] maxM: Just 353
[Info] [2018-02-27 12:58:02] else: 7
[Info] [2018-02-27 12:58:02] transmitOneC
[Info] [2018-02-27 12:58:02] maxM: Just 349
[Info] [2018-02-27 12:58:02] else: 11
[Info] [2018-02-27 12:58:02] transmitOneC
[Info] [2018-02-27 12:58:03] maxM: Just 353
[Info] [2018-02-27 12:58:03] else: 7
[Info] [2018-02-27 12:58:03] transmitOneC
[Info] [2018-02-27 12:58:03] maxM: Just 365
[Info] [2018-02-27 12:58:03] Queue "https://sqs.us-west-2.amazonaws.com/143032791481/pipecube--atlas-feedback-queue" is full
[Info] [2018-02-27 12:58:04] maxM: Just 365
[Info] [2018-02-27 12:58:04] Queue "https://sqs.us-west-2.amazonaws.com/143032791481/pipecube--atlas-feedback-queue" is full
```