### PR TITLE
New id rewrite rule

### DIFF
--- a/src/App/Options/Cmd/KafkaToSqs.hs
+++ b/src/App/Options/Cmd/KafkaToSqs.hs
@@ -259,4 +259,5 @@ rewriteOrElse f g v = f v `catchError` const (g v)
 pickRewriteJson :: Monad m => String -> ExceptT AppError m (J.Value -> ExceptT AppError m J.Value)
 pickRewriteJson strategyName = case strategyName of
   "fcm-to-rc" -> return fileChangeMessageToResourceChanged
+  "id"        -> return return
   unknown     -> throwError $ AppErr $ "Unknown rewrite strategy: " <> unknown


### PR DESCRIPTION
If you use `--rewrite-json fcm-to-rc`, then it will attempt rewrite from FCM to RC and fail otherwise.

If you use `--rewrite-json fcm-to-rc --rewrite-json id`, then it will attempt rewrite from FCM to RC or otherwise pass through.