### PR TITLE
MAYH-9842 unescape objectkey from sns notification

### DIFF
--- a/src/App/Json.hs
+++ b/src/App/Json.hs
@@ -17,15 +17,11 @@ import Data.Monoid
 import qualified Antiope.Contract.SQS.FileChangeMessage as SQSM
 import qualified Antiope.Contract.SQS.ResourceChanged   as SQSM
 import qualified Data.Aeson                             as J
-import qualified Data.Text                              as T
-import qualified Network.URI                            as URI
 
 fileChangeMessageToResourceChanged :: Monad m => J.Value -> ExceptT AppError m J.Value
 fileChangeMessageToResourceChanged v = case J.fromJSON v of
   J.Success (fcm :: SQSM.FileChangeMessage) -> return $ J.toJSON $ SQSM.ResourceChanged
     { SQSM.eventTime  = fcm ^. the @"eventTime"
-    , SQSM.uri        = "s3://" <> (fcm ^. the @"bucketName") <> "/" <> (unescape $ fcm ^. the @"objectKey")
+    , SQSM.uri        = "s3://" <> (fcm ^. the @"bucketName") <> "/" <> fcm ^. the @"objectKey"
     }
   J.Error msg                               -> throwError (AppErr msg)
-  where
-    unescape = T.pack . URI.unEscapeString . T.unpack

--- a/src/App/SqsMessage.hs
+++ b/src/App/SqsMessage.hs
@@ -14,6 +14,7 @@ import Network.AWS.SQS
 import qualified Antiope.Contract.SQS.FileChangeMessage as Z
 import qualified Data.ByteString.Char8                  as C8
 import qualified Data.Text                              as T
+import qualified Network.URI                            as URI
 
 data SqsMessage
   = SqsMessageOfS3TestEvent
@@ -67,7 +68,7 @@ decodeSqsMessage msg = do
       { Z.eventName  = eventName
       , Z.eventTime  = eventTime
       , Z.bucketName = bucketName
-      , Z.objectKey  = objectKey
+      , Z.objectKey  = T.pack . URI.unEscapeString . T.unpack $ objectKey
       , Z.objectSize = objectSize
       , Z.objectTag  = objectTag
       }


### PR DESCRIPTION
Move the unescape earlier before kafka.

Tested on `panda`:
```
panda--event-reactor=> select * from reactor_outputs limit 1;
             job_id             |                                                         output_uri                                                         |   logical_event_time   |        processing_time        |                                                                       work_message
--------------------------------+----------------------------------------------------------------------------------------------------------------------------+------------------------+-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------
 attackstream-customer-enricher | s3://panda--attackstream-parser-bucket/year=2012/month=03/day=12/alerts.211.111.210.17-03.120312.avro.gz.customer-enriched | 2012-03-12 03:00:00+00 | 2018-09-19 23:06:20.518131+00 | {"uri":"s3://panda--attackstream-parser-bucket/year=2012/month=03/day=12/alerts.211.111.210.17-03.120312.avro.gz","eventTime":"2018-09-19T23:06:18.959Z"}
(1 row)
```