### PR TITLE
MAYH-0000 ignore DeliverySuccess

### DIFF
--- a/src/App/Kafka.hs
+++ b/src/App/Kafka.hs
@@ -77,10 +77,11 @@ mkProducer = do
   snd <$> allocate prod K.closeProducer
 
 logAndDieHard :: TimedFastLogger -> K.DeliveryReport -> IO ()
-logAndDieHard lgr err = do
+logAndDieHard lgr (K.DeliveryFailure _ err) = do
   let errMsg = "Producer is unable to deliver messages: " <> show err
   pushLogMessage lgr LevelError errMsg
   error errMsg
+logAndDieHard _ _ = return ()
 
 kafkaLogLevel :: LogLevel -> K.KafkaLogLevel
 kafkaLogLevel l = case l of


### PR DESCRIPTION
`hw-kafka-client` was changed from returning only on error, to always returning a `DeliveryReport`. `DeliveryReport` can either be a `DeliverySuccess` or `DeliveryFailure`, so it's bad to always die hard.