### PR TITLE
MAYH-0000 send batches of messages and remove max message feature

### DIFF
--- a/src/App/AWS/Sqs.hs
+++ b/src/App/AWS/Sqs.hs
@@ -17,11 +17,12 @@ import qualified Text.Read as T
 
 sendSqs :: (MonadResource m, MonadAWS m)
             => Text
-            -> Text
+            -> [Text]
             -> m ()
-sendSqs sqsUrl msgBody = do
-  void $ send $ sendMessage sqsUrl msgBody
-  return ()
+sendSqs sqsUrl msgBodies = do
+  let idxs = T.pack . show <$> [1 :: Int ..]
+  let entries = (\(r, i) -> sendMessageBatchRequestEntry i r) <$> zip msgBodies idxs
+  void . send $ sendMessageBatch sqsUrl & smbEntries .~ entries
 
 getSqsApproximateNumberOfMessages
   :: (MonadResource m, MonadAWS m)


### PR DESCRIPTION
Send up to 10 SQS messages at a time, which is the maximum allowed by AWS.